### PR TITLE
fix: stop leaking a session copy on every shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ claude mcp add tg-reader -s user \
 - `.session` 等同于登录凭证：勿提交仓库、勿外泄。仓库 `.gitignore` 已忽略常见 session 文件。
 - 当前实现以**文本**为主；媒体、反应链等能力见仓库内其他说明或 issue。
 
+## 同源的其他工具
+
+完整地图：**[runesleo](https://github.com/runesleo/runesleo)** — 全部开源项目与工作系统。
+
+- [x-reader](https://github.com/runesleo/x-reader) — 通用内容阅读 MCP，支持 10+ 平台
+- [claude-code-workflow](https://github.com/runesleo/claude-code-workflow) — QuietHarness：Claude Code / Codex / Cursor 共用的 AI 工作系统
+- [ai-health-vault](https://github.com/runesleo/ai-health-vault) — AI + Obsidian 健康管理系统
+- [polymarket-toolkit](https://github.com/runesleo/polymarket-toolkit) — Polymarket 研究 CLI + AI Skills
+
 ## License
 
 MIT — 见 [LICENSE](./LICENSE)。

--- a/server.py
+++ b/server.py
@@ -14,11 +14,14 @@ Security notes:
 """
 
 import os
+import re
 import sys
 import json
 import stat
 import uuid
+import time
 import atexit
+import signal
 import asyncio
 import shutil
 import tempfile
@@ -97,6 +100,7 @@ else:
 _PID_SESSION_COPY: Path | None = None
 _PID_LOCK = threading.Lock()
 _ATEXIT_REGISTERED = False
+_PREV_HANDLERS: dict[int, Any] = {}
 
 # Initialize the MCP server.
 server = Server("tg-reader-mcp")
@@ -138,7 +142,12 @@ def _get_pid_session_path() -> str:
         _PID_SESSION_COPY = target
         if not _ATEXIT_REGISTERED:
             atexit.register(_cleanup_pid_session)
+            _install_signal_cleanup()
             _ATEXIT_REGISTERED = True
+            # Backstop for copies orphaned by SIGKILL / crashes in earlier runs.
+            n = _sweep_stale_session_copies()
+            if n:
+                print(f"[tg-reader-mcp] Swept {n} stale session file(s).", file=sys.stderr)
         return str(target.with_suffix(''))
 
 
@@ -153,6 +162,84 @@ def _cleanup_pid_session() -> None:
                 p.unlink()
         except OSError:
             pass
+
+
+def _install_signal_cleanup() -> None:
+    """Run the atexit cleanup on SIGTERM/SIGINT too.
+
+    atexit only fires on a *normal* interpreter exit. MCP clients shut the server
+    down with SIGTERM, which Python does not handle by default -- the process dies
+    without ever running the atexit hook, leaking one session copy per shutdown.
+    Chaining to any previously installed handler keeps us a good citizen.
+    """
+    def _handler(signum, frame):
+        _cleanup_pid_session()
+        prev = _PREV_HANDLERS.get(signum)
+        if callable(prev):
+            prev(signum, frame)
+            return
+        # Restore default disposition and re-raise so the exit status is honest.
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            _PREV_HANDLERS[sig] = signal.getsignal(sig)
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            # Not on the main thread, or platform refuses -- sweep still covers us.
+            pass
+
+
+def _sweep_stale_session_copies(max_age_seconds: int = 3600) -> int:
+    """Delete session copies left behind by processes that are already gone.
+
+    Signal handlers cannot cover SIGKILL or a hard crash, so this is the real
+    backstop: on every startup, drop any `tg_session_mcp_<pid>_<uuid>.session`
+    whose PID no longer exists. The age floor guards against PID reuse and
+    against racing a sibling process that just created its copy.
+
+    Returns the number of files removed. Never raises -- cleanup must not
+    prevent the server from starting.
+    """
+    removed = 0
+    pattern = re.compile(r'^tg_session_mcp_(\d+)_[0-9a-f]+$')
+    now = time.time()
+    try:
+        candidates = list(TG_READER_DIR.glob('tg_session_mcp_*.session'))
+    except OSError:
+        return 0
+
+    for path in candidates:
+        m = pattern.match(path.stem)
+        if not m:
+            continue                                  # unrecognised name: leave it alone
+        pid = int(m.group(1))
+        if pid == os.getpid():
+            continue
+        try:
+            if now - path.stat().st_mtime < max_age_seconds:
+                continue                              # too fresh: may be a live sibling
+        except OSError:
+            continue
+        try:
+            os.kill(pid, 0)                           # signal 0 = liveness probe only
+            continue                                  # still running: not ours to remove
+        except ProcessLookupError:
+            pass                                      # owner is gone -> stale
+        except PermissionError:
+            continue                                  # exists under another user
+        except OSError:
+            continue
+        for suffix in ('.session', '.session-journal'):
+            p = path.with_suffix(suffix)
+            try:
+                if p.exists():
+                    p.unlink()
+                    removed += 1
+            except OSError:
+                pass
+    return removed
 
 
 async def get_client():


### PR DESCRIPTION
## The bug

Each MCP process copies the session file to a per-process copy and relies on `atexit` to clean it up.

`atexit` only runs on a **normal** interpreter exit. MCP clients shut the server down with **SIGTERM**, which Python does not handle by default — the process dies without ever running the hook.

Result: **one orphaned session file per shutdown**, accumulating silently. Every one of them is a working Telegram credential sitting on disk. It never raises an error, so nothing surfaces it — "the cleanup code exists" and "the cleanup has never once run" can both be true.

## The fix

Two layers, because neither covers the other's case:

**1. Signal handlers** — run the same cleanup on `SIGTERM`/`SIGINT`. Chains to any previously installed handler; otherwise restores `SIG_DFL` and re-raises so the exit status stays honest (verified: child exits `-15`, not `0`). Wrapped in try/except since `signal.signal` fails off the main thread.

**2. Startup sweep** — delete copies whose owning PID no longer exists. This is the real backstop: signal handlers cannot cover `SIGKILL` or a hard crash.

Guards on the sweep:
- **Strict filename pattern** `tg_session_mcp_<pid>_<hex>` — the source session file and any unrelated session files are never matched
- **1 hour age floor** — PID reuse cannot cause deletion of a sibling's fresh copy
- `os.kill(pid, 0)` liveness probe — sends nothing, existence check only
- Never raises; cleanup must not prevent startup

## Testing

**Sweep predicates — 6/6**, in a temp dir:

| case | expected | result |
|---|---|---|
| dead PID + older than age floor | delete | ✅ |
| own PID | keep | ✅ |
| dead PID but younger than age floor | keep | ✅ |
| the source session file | keep | ✅ |
| an unrelated script's session file | keep | ✅ |
| legacy name without uuid suffix | keep | ✅ |

**SIGTERM path** — real subprocess, real signal: copy created → `SIGTERM` sent → copy gone, exit code `-15`.

**Dry preview** against a directory containing live sibling processes: every running copy preserved, only dead-PID ones selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)